### PR TITLE
🐛 fix: 회원가입 시 새로운 Setting과 User가 연관관계 설정 안 되는 문제 (#11)

### DIFF
--- a/src/main/java/com/waither/domain/noti/entity/Notification.java
+++ b/src/main/java/com/waither/domain/noti/entity/Notification.java
@@ -33,7 +33,4 @@ public class Notification extends BaseEntity {
         this.user = user;
     }
 
-    public void setCreatedAt(LocalDateTime createdAt) {
-        super.setCreatedAt(createdAt);
-    }
 }

--- a/src/main/java/com/waither/domain/noti/service/NotificationService.java
+++ b/src/main/java/com/waither/domain/noti/service/NotificationService.java
@@ -144,11 +144,11 @@ public class NotificationService {
 
         String region = weatherService.convertGpsToRegionName(locationDto.latitude(), locationDto.longitude());
 
-        saveOrUpdateLocation(currentUser.getEmail(), region);
+        saveOrUpdateLocation(currentUser, region);
 
     }
 
-    private void saveOrUpdateLocation(String email, String region) {
+    private void saveOrUpdateLocation(User currentUser, String region) {
         LocalDateTime fourHoursAgo = LocalDateTime.now().minusHours(4);
         notificationRecordRepository.findByEmail(currentUser.getEmail())
                 .ifPresentOrElse(

--- a/src/main/java/com/waither/domain/user/service/commandService/UserService.java
+++ b/src/main/java/com/waither/domain/user/service/commandService/UserService.java
@@ -59,15 +59,15 @@ public class UserService {
 //            throw new CustomException(ErrorCode.INVALID_Account);
 //        }
         User newUser = UserConverter.toUser(requestDto, passwordEncoder);
-        processAfterSignup(newUser);
-        userRepository.save(newUser);
+        User user = userRepository.save(newUser);
+        processAfterSignup(user);
     }
 
     // 회원가입 (카카오)
     public void signupForKakao(KakaoResDto.UserInfoResponseDto userInfo) {
         User newUser = UserConverter.toUser(userInfo);
-        processAfterSignup(newUser);
-        userRepository.save(newUser);
+        User user = userRepository.save(newUser);
+        processAfterSignup(user);
     }
 
     private void processAfterSignup(User newUser) {


### PR DESCRIPTION
# ☝️Issue Number

- #11 

# 🔎 Key Changes
- User 엔티티 저장 후 Default Setting 저장 로직으로 변경
